### PR TITLE
Updated emuMMC partition naming step

### DIFF
--- a/emummc/mac.rst
+++ b/emummc/mac.rst
@@ -50,11 +50,11 @@ Once you are ready, follow the guide below:
 
 
     .. warning::
-        The first partition must not be called "SWITCH" otherwise the homebrew menu will not be able to locate or open the /switch folder or any apps or games stored on this partition. In this example, it has been named "SWPART", you can name it whatever you like.
+        The first partition must not be called "SWITCH" otherwise the homebrew menu will not be able to locate or open the /switch folder or any apps or games stored on this partition. In this example, it has been named "SWITCHSD", you can name it whatever you like.
 
     ::
 
-        diskutil partitionDisk disk# MBR fat32 "SWPART" PutSizeHere fat32 "EMUMMC" 31306285056
+        diskutil partitionDisk disk# MBR fat32 "SWITCHSD" PutSizeHere fat32 "EMUMMC" 31306285056
 
     .. image:: ../images/mac/Step5.png
 

--- a/emummc/mac.rst
+++ b/emummc/mac.rst
@@ -48,9 +48,13 @@ Once you are ready, follow the guide below:
     .. danger::
         This is highly destructive triple check you have the correct disk number as this will partition and format the disk.
 
+
+    .. warning::
+        The first partition must not be called "SWITCH" otherwise the homebrew menu will not be able to locate or open the /switch folder or any apps or games stored on this partition. In this example, it has been named "SWPART", you can name it whatever you like.
+
     ::
 
-        diskutil partitionDisk disk# MBR fat32 "SWITCH" PutSizeHere fat32 "EMUMMC" 31306285056
+        diskutil partitionDisk disk# MBR fat32 "SWPART" PutSizeHere fat32 "EMUMMC" 31306285056
 
     .. image:: ../images/mac/Step5.png
 


### PR DESCRIPTION
I encountered a bug when naming my first partition "SWITCH" and found the workaround to be renaming the partition to something else. Updating the docs here.