### PR TITLE
Fix emummc pathing

### DIFF
--- a/hacking/caffeine/aftersetup.rst
+++ b/hacking/caffeine/aftersetup.rst
@@ -57,8 +57,13 @@ It is highly recommended that you setup emuMMC to protect your Switch from brick
 .. raw:: html
 
 	<div class="admonition warning">
-		<p class="last">To setup emuMMC, continue to <a href="/hacking/emummc">emuMMC</a></p>
+		<p class="last">Continue to:<br>
+			<a href="/emummc/windows">Create an emuMMC on Windows</a><br>
+			<a href="/emummc/mac">Create an emuMMC on Mac OS</a><br>
+			<a href="/emummc/linux">Create an emuMMC on Linux</a>
+		</p>
 	</div>
+
 
 .. toctree::
    :maxdepth: 2

--- a/hacking/fuseegelee/aftersetup.rst
+++ b/hacking/fuseegelee/aftersetup.rst
@@ -47,9 +47,9 @@ It is very highly recommended that you setup emuMMC to protect your Switch from 
 
 	<div class="admonition warning">
 		<p class="last">Continue to:<br>
-		<a href="/emummc/windows">Create an emuMMC on Windows</a></p>
+		<a href="/emummc/windows">Create an emuMMC on Windows</a></p><br>
 		<a href="/emummc/mac">Create an emuMMC on Mac OS</a><br>
-		<a href="/emummc/linux">Create an emuMMC on Linux</a><br>
+		<a href="/emummc/linux">Create an emuMMC on Linux</a>
 	</div>
 
 

--- a/hacking/fuseegelee/aftersetup.rst
+++ b/hacking/fuseegelee/aftersetup.rst
@@ -46,7 +46,10 @@ It is very highly recommended that you setup emuMMC to protect your Switch from 
 .. raw:: html
 
 	<div class="admonition warning">
-		<p class="last">To setup emuMMC, continue to <a href="/emummc/linux">Create an emuMMC on Linux</a>, <a href="/emummc/mac">Create an emuMMC on Mac OS</a>, or <a href="/emummc/windows">Create an emuMMC on Windows</a></p>
+		<p class="last">Continue to:<br>
+		<a href="/emummc/windows">Create an emuMMC on Windows</a></p>
+		<a href="/emummc/mac">Create an emuMMC on Mac OS</a><br>
+		<a href="/emummc/linux">Create an emuMMC on Linux</a><br>
 	</div>
 
 

--- a/hacking/fuseegelee/aftersetup.rst
+++ b/hacking/fuseegelee/aftersetup.rst
@@ -47,9 +47,10 @@ It is very highly recommended that you setup emuMMC to protect your Switch from 
 
 	<div class="admonition warning">
 		<p class="last">Continue to:<br>
-		<a href="/emummc/windows">Create an emuMMC on Windows</a></p><br>
-		<a href="/emummc/mac">Create an emuMMC on Mac OS</a><br>
-		<a href="/emummc/linux">Create an emuMMC on Linux</a>
+			<a href="/emummc/windows">Create an emuMMC on Windows</a><br>
+			<a href="/emummc/mac">Create an emuMMC on Mac OS</a><br>
+			<a href="/emummc/linux">Create an emuMMC on Linux</a>
+		</p>
 	</div>
 
 

--- a/hacking/nereba/aftersetup.rst
+++ b/hacking/nereba/aftersetup.rst
@@ -54,8 +54,13 @@ It is very highly recommended that you setup emuMMC to protect your Switch from 
 .. raw:: html
 
 	<div class="admonition warning">
-		<p class="last">To setup emuMMC, continue to <a href="/hacking/emummc">emuMMC</a></p>
+		<p class="last">Continue to:<br>
+			<a href="/emummc/windows">Create an emuMMC on Windows</a><br>
+			<a href="/emummc/mac">Create an emuMMC on Mac OS</a><br>
+			<a href="/emummc/linux">Create an emuMMC on Linux</a>
+		</p>
 	</div>
+
 
 
 .. toctree::


### PR DESCRIPTION
Nereba and Caffeine aftersetup.rst links to an emummc landing page that doesn't exist. Fix this.

This also cleans up the HTML.