### PR TITLE
Clean up contradictory instructions about NAND backups (#82)

### DIFF
--- a/hacking/caffeine/safetyprecautions.rst
+++ b/hacking/caffeine/safetyprecautions.rst
@@ -6,7 +6,7 @@
 Safety Precautions (Caffeine)
 ================================
 
-You are now able to run Hekate on your Nintendo Switch to launch the Atmosphere custom firmware. These next steps will make sure your being as careful as possible in regards to keeping your Switch from bricking and getting banned. These steps are optional but highly recommended
+You are now able to run Hekate on your Nintendo Switch to launch the Atmosphere custom firmware. These next steps will make sure your being as careful as possible in regards to keeping your Switch from bricking and getting banned.
 
 .. note:: 
    If something goes wrong or you need help, check `troubleshooting </troubleshooting.html>`_.


### PR DESCRIPTION
Remove the text from the initial paragraph mentioning that the NAND backup may be considered optional.